### PR TITLE
Dockerfile의 도커 이미지 빌드 오류 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorreto:17-alpine-jdk
+FROM amazoncorretto:17-alpine-jdk
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
### ✅ 이슈
- close #6 

### ✏️ 작업내용
- Dockerfile을 사용해 도커 이미지를 빌드하는 과정에서 FROM 빌드할 JDK명 오타 수정
-> amazoncorreto -> amazoncorretto