### PR TITLE
EC2 배포 시 bash 스크립트 구문 오류 해결

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -85,6 +85,6 @@ jobs:
           envs: IMAGE_FULL_PATH, DOCKERHUB_IMAGE_NAME # docker-compose.yml 에서 사용할 환경 변수
           debug: true
           script: |
-            echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }} | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+            echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
             docker compose up -d
             docker image prune -a -f


### PR DESCRIPTION
### ✅ 이슈
- close #8 

### ✏️ 작업내용
- 기존 develop build deploy 워크플로우의 EC2 Deploy 작업에서 도커 로그인 스크립트의 " 누락 수정