### PR TITLE
nginx default.conf proxy_set_header 인자 오타 에러 해결

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -21,6 +21,6 @@ server {
         proxy_pass http://localhost:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }


### PR DESCRIPTION
### ✏️ 작업내용
- nginx default.conf 설정 파일의 proxy_set_header X-Forward-For 인자값을 X-Forwarded-For로 수정