### PR TITLE
도커 컨테이너 네트워크 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,21 @@
 version: '3.8'
 
+networks:
+  my-network:
+    driver: bridge
+
+
 services:
   backend:
     image: ${IMAGE_FULL_PATH}
     container_name: ${DOCKERHUB_IMAGE_NAME}
     restart: always
+    ports:
+      - "8080:8080"
     environment:
       - TZ=Asia/Seoul
-    network_mode: host
+    networks:
+      - "my-network"
     env_file:
       - .env
 
@@ -18,15 +26,16 @@ services:
       - "6379:6379"
     environment:
       - TZ=Asia/Seoul
-    network_mode: host
+    networks:
+      - "my-network"
 
   nginx:
     image: "nginx:alpine"
     container_name: nginx
+    restart: always
     ports:
       - "80:80"
       - "443:443"
-    restart: always
     volumes:
       # nginx.conf 파일은 컨테이너 생성 시 자동으로 생성되는 기본 nginx.conf 파일을 그대로 사용
       # 기본 default.conf 파일을 커스텀한 default.conf 파일로 마운트
@@ -38,7 +47,8 @@ services:
       - certbot
     environment:
       - TZ=Asia/Seoul
-    network_mode: host
+    networks:
+      - "my-network"
 
   certbot:
     image: certbot/certbot

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -18,7 +18,7 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/testapi-sh.kro.kr/privkey.pem;
 
     location / {
-        proxy_pass http://localhost:8080;
+        proxy_pass http://github-actions-cicd:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
### ✅ 이슈
- close #16 

### ✏️ 작업내용
- 도커 컨테이너들을 독립된 네트워크로 관리하기 위해 networks: my-network 생성
- backend 컨테이너 포트 바인딩 (8080:8080)
- nginx default.conf 파일의 proxy_pass 설정 경로 수정 (컨테이너 이름:포트번호)