### PR TITLE
초기 인증서 발급을 위해 Nginx SSL 설정 제거

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -2,25 +2,12 @@ server {
     listen 80;
     server_name testapi-sh.kro.kr;
 
-    return 301 https://$host$request_uri;
-
     location /.well-known/acme-challenge/ {
         allow all;
         root /var/www/certbot;
     }
-}
-
-server {
-    listen 443 ssl;
-    server_name testapi-sh.kro.kr;
-
-    ssl_certificate /etc/letsencrypt/live/testapi-sh.kro.kr/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/testapi-sh.kro.kr/privkey.pem;
 
     location / {
-        proxy_pass http://github-actions-cicd:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        return 301 https://$host$request_uri;
     }
 }


### PR DESCRIPTION
### ✅ 이슈
- close #18 

<br>

### ✏️ 작업내용
- Nginx default.conf 파일의 HTTP(80) 요청에 대한 설정 파일 수정 및 HTTPS(443) 요청에 대한 설정 비활성화

<br>

### 💡 트러블슈팅
- 현재 배포환경에 초기 SSL 인증서를 발급받지 않은 상태이지만, Nginx default.conf 설정에서 모든 HTTP(80번) 요청을 HTTPS(443번) 으로 리다이렉트하도록 설정되어있었다. 
```
server {
    listen 80;
    server_name testapi-sh.kro.kr;

    return 301 https://$host$request_uri;  # 이 부분이 문제, 이 코드가 먼저 실행되면서 Certbot 인증이 불가능했다

    location /.well-known/acme-challenge/ {
        allow all;
        root /var/www/certbot;
    }
}
```
- Certbot에서 인증서를 발급할 때, **HTTP-01 인증 방식**을 사용해 `/var/www/certbot/.well-known/acme-challenge/` 경로에 인증 파일을 생성하고, Lets Encrypt 서버가 `http://{domain}/.well-known/acme-challenge/`로 접근하여 해당 파일을 확인한 후, 파일이 정상적으로 확인되면 SSL 인증서가 발급된다. 
- 수정 전 설정을 보면, `location /.well-known/acme-challenge/` 설정을 통해 인증 관련 설정을 잘 적용했지만,  `return 301 https://$host$request_uri;` 코드가 먼저 실행되어 모든 HTTP(80번) 요청이 HTTPS(443)으로 강제 리다이렉트 되었다.
이로 인해 Lets Encrypt 서버가 HTTP로 인증을 시도할 수 없어 결과적으로 인증서 발급이 실패해 SSL 인증서를 찾을 수 없다는 오류가 발생했다.
- `return 301 https://$host$request_uri;` 코드를 지우고, location /.well-known/acme-challenge/ 설정 아래 `location / `설정을 추가해 인증 요청을 제외한 모든 HTTP 요청은 HTTPS(443)으로 리다이렉트하도록 수정했다.
```
server {
    listen 80;
    server_name testapi-sh.kro.kr;

    location /.well-known/acme-challenge/ {
        allow all;
        root /var/www/certbot;
    }

    location / {
        return 301 https://$host$redirect_uri;
    }
}
```
- 또한 `server { listen 443 ssl; }` 에 대한 설정은 유지해도 괜찮지만, 인증서 발급 전에는 인증서 파일이 존재하지 않는데 존재하지 않는 파일을 참조하면서 Nginx가 실행되지 않을 수 있는 문제가 발생할 수 있어 초기 인증서 발급 전에 `listen 443 ssl;` 설정을 비활성화 시켜두고 초기 인증서를 발급 받은 후 다시 활성화 시킬 예정이다.