### PR TITLE
nginx default.conf 파일 https(443번) 요청 설정 활성화

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -11,3 +11,18 @@ server {
         return 301 https://$host$request_uri;
     }
 }
+
+server {
+    listen 443 ssl;
+    server_name testapi-sh.kro.kr;
+
+    ssl_certificate /etc/letsencrypt/live/testapi-sh.kro.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/testapi-sh.kro.kr/privkey.pem;
+
+    location / {
+        proxy_pass http://github-actions-cicd:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}


### PR DESCRIPTION
### ✅ 이슈
- close #20 

### ✏️ 작업내용
- 초기 SSL 인증서 발급을 위해 비활성화 해둔 HTTPS(443번) 요청에 대한 설정 활성화