### PR TITLE
certbot ssl 인증서 발급 정보 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,4 +55,4 @@ services:
     volumes:
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot certonly; sleep 12h & wait $${!}; done;'"
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew --quiet && nginx -s reload; sleep 12h & wait $${!}; done;'"


### PR DESCRIPTION
### ✅ 이슈
- close #22 

### ✏️ 작업내용
- docker-compose.yml 파일에서 certbot을 이용한 ssl 인증서 발급 관련 entrypoint 수정
- 기존 `certbot certolny` 명령어에서 `certbot renew --quite && nginx -s reload` 로 변경
- 기존의 `certbot certonly` 명령은 매번 새로운 인증서를 발급받는 방식으로 불필요한 인증서 재발급을 방지하도록 변경, certbot 인증서 발급 요청은 Lets Encrypt의 발급 제한이 적용되 매번 새로운 인증서 발급을 요청하면 요청 횟수 초과로 인해서 인증서 발급이 차단될 가능성이 있다고함.
- 이를 방지하기 위해 renew 명령을 사용해 기존 인증서를 갱신하는 방식으로 변경하고, 갱신 이후 nginx를 자동으로 reload해 변경 사항이 적용되도록 수정  