### PR TITLE
백엔드 컨테이너 포트 접근 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
   redis:
     image: "redis:alpine"
     container_name: redis
-    ports:
-      - "6379:6379"
+    expose:
+      - "8080"
     environment:
       - TZ=Asia/Seoul
     networks:


### PR DESCRIPTION
### ✅ 이슈
- close #24 

### ✏️ 작업내용
- docker-compose.yml 파일에서 백엔드 컨테이너 `ports: - "8080:8080"` -> `expose: - "8080"` 으로 변경
- `ports` 는 호스트와 컨테이너 간의 포트 매핑을 설정하고 외부에서도 접근이 가능하지만 도커 컨테이너 내부 네트워크에서만 접근 가능하도록 하기 위해 `expose` 로 변경해 보안성을 높이고 불필요한 외부 노출 방지
- 같은 내부 네트워크를 사용하는 Nginx에서만 백엔드 컨테이너에 접근하도록 변경