### PR TITLE
도커 컴포즈 포트 에러 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     image: ${IMAGE_FULL_PATH}
     container_name: ${DOCKERHUB_IMAGE_NAME}
     restart: always
-    ports:
-      - "8080:8080"
+    expose: 
+      - "8080"
     environment:
       - TZ=Asia/Seoul
     networks:
@@ -22,8 +22,8 @@ services:
   redis:
     image: "redis:alpine"
     container_name: redis
-    expose:
-      - "8080"
+    ports:
+      - "6379:6379"
     environment:
       - TZ=Asia/Seoul
     networks:


### PR DESCRIPTION
### ✅ 이슈
- close #31  

### ✏️ 작업내용
- 커밋 4f2cdfa5d03692b0acf15aaf2aeee6004e09399e 에서 backend 컨테이너가 아닌 redis 컨테이너 포트를 `expose "8080"` 으로 잘못 수정한 작업에 대해서 다시 수정