### PR TITLE
도커 이미지 태그 지정 방법 변경

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -57,7 +57,8 @@ jobs:
           DOCKERHUB_IMAGE_FULL_NAME: ${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}
         with:
           images: ${{ env.DOCKERHUB_IMAGE_FULL_NAME }}
-          tags: latest
+          tags: |
+            type=sha,prefix=
 
       # Docker 이미지 빌드, 도커허브 푸시
       - name: Build and Push Docker image


### PR DESCRIPTION
### ✅ 이슈
- close #30 

### ✏️ 작업내용
- 기존 워크플로우에서 빌드된 jar 파일을 도커 이미지로 빌드할 때 태그를 latest로 지정했는데 배포 환경에서 최신 이미지가 갱신되지 않는 문제 발생, latest 태그는 같은 이름의 이미지가 이미 존재해서 도커 허브에 갱신하더라도 최신 이미지가 아닌 기존의 캐시된 이미지가 사용될 가능성이 있어 유니크한 태그를 지정하기로 변경
- 배포 환경에서 강제로 이미지를 최신 이미지를 pull 해올 수도 있지만 배포 스크립트를 수정하지 않고 도커 이미지에 유니크한 태그를 지정해 해당 태그를 가진 이미지를 가져올 수 있도록 수정
- Git 커밋 해시를 기반으로 도커 이미지 태그를 생성하도록 변경